### PR TITLE
Store MCUSR into R2 on bootup

### DIFF
--- a/src/bootloader.cpp
+++ b/src/bootloader.cpp
@@ -48,18 +48,13 @@ MCP2515 mcp2515;
 void get_mcusr(void) __attribute__((naked)) __attribute__((used)) __attribute__((section(".init3")));
 void get_mcusr(void) {
   #if defined(MCUCSR)
+    #if MCUSR_TO_R2
+      __asm__ __volatile__("  mov r2, %0\n" ::"r"(MCUCSR));
+    #endif
     MCUCSR = 0;
   #else
-    #if MCUSR_TO_GPIOR0
-      /* The MCU Status Register provides information on which reset
-       * source caused an MCU reset.
-       * 0x01 Power-on
-       * 0x02 External
-       * 0x04 Brown-out
-       * 0x08 Watchdog
-       * 0x10 JTAG
-       */
-      GPIOR0 = MCUSR; /* store MCUSR in to General Purpose I/O Register 0 */
+    #if MCUSR_TO_R2
+      __asm__ __volatile__("  mov r2, %0\n" ::"r"(MCUSR));
     #endif
     MCUSR = 0;
   #endif

--- a/src/bootloader.cpp
+++ b/src/bootloader.cpp
@@ -50,6 +50,15 @@ void get_mcusr(void) {
   #if defined(MCUCSR)
     MCUCSR = 0;
   #else
+  /* The MCU Status Register provides information on which reset
+   * source caused an MCU reset.
+   * 0x01 Power-on
+   * 0x02 External
+   * 0x04 Brown-out
+   * 0x08 Watchdog
+   * 0x10 JTAG
+   */
+    GPIOR0 = MCUSR; /* store MCUSR in to General Purpose I/O Register 0 */
     MCUSR = 0;
   #endif
   wdt_disable();

--- a/src/bootloader.cpp
+++ b/src/bootloader.cpp
@@ -47,15 +47,21 @@ MCP2515 mcp2515;
  */
 void get_mcusr(void) __attribute__((naked)) __attribute__((used)) __attribute__((section(".init3")));
 void get_mcusr(void) {
-  #ifndef MCUSR  // Backward compatability with old AVRs
-    #define MCUSR MCUCSR
-  #endif
-
+#if defined(MCUCSR)
   #if MCUSR_TO_R2
-    __asm__ __volatile__("  mov r2, %[reset_caused_by_val] ;Move Between Registers \n\t"
-                         ::[reset_caused_by_val] "r" (MCUSR));
+    __asm__ __volatile__(
+        "  mov r2, %[reset_caused_by_val] ;Move Between Registers \n\t" 
+        ::[reset_caused_by_val] "r"(MCUCSR));
+  #endif
+  MCUCSR = 0;
+#else
+  #if MCUSR_TO_R2
+    __asm__ __volatile__(
+        "  mov r2, %[reset_caused_by_val] ;Move Between Registers \n\t"
+        ::[reset_caused_by_val] "r"(MCUSR));
   #endif
   MCUSR = 0;
+#endif
   wdt_disable();
 }
 

--- a/src/bootloader.cpp
+++ b/src/bootloader.cpp
@@ -50,15 +50,17 @@ void get_mcusr(void) {
   #if defined(MCUCSR)
     MCUCSR = 0;
   #else
-  /* The MCU Status Register provides information on which reset
-   * source caused an MCU reset.
-   * 0x01 Power-on
-   * 0x02 External
-   * 0x04 Brown-out
-   * 0x08 Watchdog
-   * 0x10 JTAG
-   */
-    GPIOR0 = MCUSR; /* store MCUSR in to General Purpose I/O Register 0 */
+    #if MCUSR_TO_GPIOR0
+      /* The MCU Status Register provides information on which reset
+       * source caused an MCU reset.
+       * 0x01 Power-on
+       * 0x02 External
+       * 0x04 Brown-out
+       * 0x08 Watchdog
+       * 0x10 JTAG
+       */
+      GPIOR0 = MCUSR; /* store MCUSR in to General Purpose I/O Register 0 */
+    #endif
     MCUSR = 0;
   #endif
   wdt_disable();

--- a/src/config.h
+++ b/src/config.h
@@ -43,14 +43,20 @@
  * The MCU Status Register provides information on which reset source
  * caused an MCU reset.
  *
- * [code main prog.]
+ * paste this code into your program (not the bootloader)
+ * \code
+ *      uint8_t mcusr __attribute__ ((section (".noinit")));//<= the MCU Status Register
+ *      void getMCUSR(void) __attribute__((naked)) __attribute__((section(".init0")));
+ *      void getMCUSR(void)
+ *      {
+ *          __asm__ __volatile__ ( "mov %0, r2 \n" : "=r" (mcusr) : );
+ *       }
+ * \endcode
  *
- * uint8_t mcusr __attribute__ ((section (".noinit")));//<= the MCU Status Register
- * void getMCUSR(void) __attribute__((naked)) __attribute__((section(".init0")));
- * void getMCUSR(void)
- * {
- *     __asm__ __volatile__ ( "mov %0, r2 \n" : "=r" (mcusr) : );
- *  }
+ * to use
+ * \code
+ *      mcusr;//<= the MCU Status Register (global variable)
+ * \endcode
  */
 #define MCUSR_TO_R2 1
 

--- a/src/config.h
+++ b/src/config.h
@@ -39,6 +39,15 @@
 #define TIMEOUT 250
 
 /**
+ * store The MCU Status Register to General Purpose I/O Register 0
+ * The MCU Status Register provides information on which reset source
+ * caused an MCU reset.
+ * note: only for MCUSR not MCUCSR 
+ * see: https://github.com/crycode-de/mcp-can-boot/pull/2#issuecomment-851257516
+ */
+//#define MCUSR_TO_GPIOR0
+
+/**
  * Data rate of the CAN bus.
  * CAN_5KBPS, CAN_10KBPS, CAN_20KBPS, CAN_31K25BPS, CAN_33KBPS, CAN_40KBPS,
  * CAN_50KBPS, CAN_80KBPS, CAN_83K3BPS, CAN_95KBPS, CAN_100KBPS, CAN_125KBPS,

--- a/src/config.h
+++ b/src/config.h
@@ -39,13 +39,20 @@
 #define TIMEOUT 250
 
 /**
- * store The MCU Status Register to General Purpose I/O Register 0
+ * store The MCU Status Register to Register 2
  * The MCU Status Register provides information on which reset source
  * caused an MCU reset.
- * note: only for MCUSR not MCUCSR 
- * see: https://github.com/crycode-de/mcp-can-boot/pull/2#issuecomment-851257516
+ *
+ * [code main prog.]
+ *
+ * uint8_t mcusr __attribute__ ((section (".noinit")));//<= the MCU Status Register
+ * void getMCUSR(void) __attribute__((naked)) __attribute__((section(".init0")));
+ * void getMCUSR(void)
+ * {
+ *     __asm__ __volatile__ ( "mov %0, r2 \n" : "=r" (mcusr) : );
+ *  }
  */
-//#define MCUSR_TO_GPIOR0
+#define MCUSR_TO_R2 1
 
 /**
  * Data rate of the CAN bus.

--- a/src/config.h
+++ b/src/config.h
@@ -45,17 +45,32 @@
  *
  * paste this code into your program (not the bootloader)
  * \code
- *      uint8_t mcusr __attribute__ ((section (".noinit")));//<= the MCU Status Register
- *      void getMCUSR(void) __attribute__((naked)) __attribute__((section(".init0")));
- *      void getMCUSR(void)
- *      {
- *          __asm__ __volatile__ ( "mov %0, r2 \n" : "=r" (mcusr) : );
- *       }
+ *  uint8_t mcusr __attribute__ ((section (".noinit")));//<= the MCU Status Register
+ *  void getMCUSR(void) __attribute__((naked)) __attribute__((section(".init0")));
+ *  void getMCUSR(void)
+ *  {
+ *      __asm__ __volatile__ ( "mov %0, r2 \n" : "=r" (mcusr) : );
+ *  }
  * \endcode
  *
  * to use
  * \code
- *      mcusr;//<= the MCU Status Register (global variable)
+ *  mcusr;//<= the MCU Status Register (global variable)
+ * \endcode
+ *
+ * or
+ *
+ * \code
+ *  void main()
+ *  {
+ *      uint8_t mcusr;
+ *      __asm__ __volatile__ ( "mov %0, r2 \n" : "=r" (mcusr) : );
+ *  }
+ * \endcode
+ *
+ * to use
+ * \code
+ *  mcusr;//<= the MCU Status Register (local variable in function main)
  * \endcode
  */
 #define MCUSR_TO_R2 1


### PR DESCRIPTION
this makes it possible to find the MCU reset caused in run code.
because the MCUSR is being erased by the bootloader.