### PR TITLE
optimizations to reduce bootloader size

### DIFF
--- a/src/bootloader.cpp
+++ b/src/bootloader.cpp
@@ -143,7 +143,7 @@ int main () {
   canMsg.data[5] = SIGNATURE_1;
   canMsg.data[6] = SIGNATURE_2;
   canMsg.data[7] = BOOTLOADER_CMD_VERSION;
-  mcp2515.sendMessage(&canMsg);
+  mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
 
   // local vars for timed actions
   uint32_t startTime = millis();
@@ -212,7 +212,7 @@ int main () {
             canMsg.data[5] = (flashAddr >> 16) & 0xFF;
             canMsg.data[6] = (flashAddr >> 8) & 0xFF;
             canMsg.data[7] = flashAddr & 0xFF;
-            mcp2515.sendMessage(&canMsg);
+            mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
 
           }
 
@@ -239,7 +239,7 @@ int main () {
             canMsg.data[5] = (flashAddr >> 16) & 0xFF;
             canMsg.data[6] = (flashAddr >> 8) & 0xFF;
             canMsg.data[7] = flashAddr & 0xFF;
-            mcp2515.sendMessage(&canMsg);
+            mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
 
           } else if (canMsg.data[CAN_DATA_BYTE_CMD] == CMD_FLASH_READ) {
             // read flash memory at given address
@@ -253,7 +253,7 @@ int main () {
               canMsg.data[5] = ((uint32_t)FLASHEND_BL >> 16) & 0xFF;
               canMsg.data[6] = ((uint32_t)FLASHEND_BL >> 8) & 0xFF;
               canMsg.data[7] = FLASHEND_BL & 0xFF;
-              mcp2515.sendMessage(&canMsg);
+              mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
               continue;
             }
 
@@ -271,7 +271,7 @@ int main () {
 
             canMsg.data[CAN_DATA_BYTE_CMD]          = CMD_FLASH_READ_DATA;
             canMsg.data[CAN_DATA_BYTE_LEN_AND_ADDR] = (len << 5) | (readFlashAddr & 0b00011111);  // number of data bytes read and address part
-            mcp2515.sendMessage(&canMsg);
+            mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
 
           } else if (canMsg.data[CAN_DATA_BYTE_CMD] == CMD_FLASH_SET_ADDRESS) {
             // set the start address for flashing
@@ -287,7 +287,7 @@ int main () {
               canMsg.data[5] = ((uint32_t)FLASHEND_BL >> 16) & 0xFF;
               canMsg.data[6] = ((uint32_t)FLASHEND_BL >> 8) & 0xFF;
               canMsg.data[7] = FLASHEND_BL & 0xFF;
-              mcp2515.sendMessage(&canMsg);
+              mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
               continue;
             }
 
@@ -308,7 +308,7 @@ int main () {
             canMsg.data[5] = (flashAddr >> 16) & 0xFF;
             canMsg.data[6] = (flashAddr >> 8) & 0xFF;
             canMsg.data[7] = flashAddr & 0xFF;
-            mcp2515.sendMessage(&canMsg);
+            mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
 
           } else if (canMsg.data[CAN_DATA_BYTE_CMD] == CMD_FLASH_DATA) {
             // data for flashing
@@ -322,7 +322,7 @@ int main () {
               canMsg.data[5] = (flashAddr >> 16) & 0xFF;
               canMsg.data[6] = (flashAddr >> 8) & 0xFF;
               canMsg.data[7] = flashAddr & 0xFF;
-              mcp2515.sendMessage(&canMsg);
+              mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
               continue;
             }
 
@@ -336,7 +336,7 @@ int main () {
               canMsg.data[5] = ((uint32_t)FLASHEND_BL >> 16) & 0xFF;
               canMsg.data[6] = ((uint32_t)FLASHEND_BL >> 8) & 0xFF;
               canMsg.data[7] = FLASHEND_BL & 0xFF;
-              mcp2515.sendMessage(&canMsg);
+              mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
               continue;
             }
             for (uint8_t i = 0; i < len; i++) {
@@ -356,7 +356,7 @@ int main () {
             canMsg.data[5] = (flashAddr >> 16) & 0xFF;
             canMsg.data[6] = (flashAddr >> 8) & 0xFF;
             canMsg.data[7] = flashAddr & 0xFF;
-            mcp2515.sendMessage(&canMsg);
+            mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
 
           } else if (canMsg.data[CAN_DATA_BYTE_CMD] == CMD_FLASH_DONE) {
             // flashing done...
@@ -372,7 +372,7 @@ int main () {
             canMsg.data[5] = 0x00;
             canMsg.data[6] = 0x00;
             canMsg.data[7] = 0x00;
-            mcp2515.sendMessage(&canMsg);
+            mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
 
             // delay for 50ms to let the mcp send the message
             delay(50);
@@ -400,7 +400,7 @@ int main () {
             canMsg.data[5] = 0x00;
             canMsg.data[6] = 0x00;
             canMsg.data[7] = 0x00;
-            mcp2515.sendMessage(&canMsg);
+            mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
 
           } else if (canMsg.data[CAN_DATA_BYTE_CMD] == CMD_START_APP) {
             // just start the main application now
@@ -410,7 +410,7 @@ int main () {
             canMsg.data[5] = 0x00;
             canMsg.data[6] = 0x00;
             canMsg.data[7] = 0x00;
-            mcp2515.sendMessage(&canMsg);
+            mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
 
             // delay for 50ms to let the mcp send the message
             delay(50);

--- a/src/bootloader.cpp
+++ b/src/bootloader.cpp
@@ -154,7 +154,7 @@ int main () {
   canMsg.data[5] = SIGNATURE_1;
   canMsg.data[6] = SIGNATURE_2;
   canMsg.data[7] = BOOTLOADER_CMD_VERSION;
-  mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
+  mcp2515.sendMessage(&canMsg);
 
   // local vars for timed actions
   uint32_t startTime = millis();
@@ -218,7 +218,7 @@ int main () {
 
             // send flash ready message
             prepMsg(CMD_FLASH_READY, 0x00, flashAddr);
-            mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
+            mcp2515.sendMessage(&canMsg);
 
           }
 
@@ -240,7 +240,7 @@ int main () {
             flashAddr = 0;
 
             prepMsg(CMD_FLASH_READY, 0x00, flashAddr);
-            mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
+            mcp2515.sendMessage(&canMsg);
 
           } else if (canMsg.data[CAN_DATA_BYTE_CMD] == CMD_FLASH_READ) {
             // read flash memory at given address
@@ -249,7 +249,7 @@ int main () {
             if (readFlashAddr > FLASHEND_BL) {
               // flash read after flash end
               prepMsg(CMD_FLASH_READ_ADDRESS_ERROR, 0x00, FLASHEND_BL);
-              mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
+              mcp2515.sendMessage(&canMsg);
               continue;
             }
 
@@ -267,7 +267,7 @@ int main () {
 
             canMsg.data[CAN_DATA_BYTE_CMD]          = CMD_FLASH_READ_DATA;
             canMsg.data[CAN_DATA_BYTE_LEN_AND_ADDR] = (len << 5) | (readFlashAddr & 0b00011111);  // number of data bytes read and address part
-            mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
+            mcp2515.sendMessage(&canMsg);
 
           } else if (canMsg.data[CAN_DATA_BYTE_CMD] == CMD_FLASH_SET_ADDRESS) {
             // set the start address for flashing
@@ -278,7 +278,7 @@ int main () {
             if (newFlashAddr > FLASHEND_BL) {
               // address cannot be flashed
               prepMsg(CMD_FLASH_ADDRESS_ERROR, 0x00, FLASHEND_BL);
-              mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
+              mcp2515.sendMessage(&canMsg);
               continue;
             }
 
@@ -294,7 +294,7 @@ int main () {
 
             // send flash ready
             prepMsg(CMD_FLASH_READY, 0x00, flashAddr);
-            mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
+            mcp2515.sendMessage(&canMsg);
 
           } else if (canMsg.data[CAN_DATA_BYTE_CMD] == CMD_FLASH_DATA) {
             // data for flashing
@@ -303,7 +303,7 @@ int main () {
             if ((flashAddr & 0b00011111) != (canMsg.data[CAN_DATA_BYTE_LEN_AND_ADDR] & 0b00011111)) {
               // send flash data error with the exprected flash address
               prepMsg(CMD_FLASH_DATA_ERROR, 0x00, flashAddr);
-              mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
+              mcp2515.sendMessage(&canMsg);
               continue;
             }
 
@@ -312,7 +312,7 @@ int main () {
             if ((flashAddr + len - 1) > FLASHEND_BL) {
               // address cannot be flashed
               prepMsg(CMD_FLASH_ADDRESS_ERROR, 0x00, FLASHEND_BL);
-              mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
+              mcp2515.sendMessage(&canMsg);
               continue;
             }
             for (uint8_t i = 0; i < len; i++) {
@@ -327,7 +327,7 @@ int main () {
 
             // send flash ready
             prepMsg(CMD_FLASH_READY, len, flashAddr);
-            mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
+            mcp2515.sendMessage(&canMsg);
 
           } else if (canMsg.data[CAN_DATA_BYTE_CMD] == CMD_FLASH_DONE) {
             // flashing done...
@@ -338,7 +338,7 @@ int main () {
 
             // send start app
             prepMsg(CMD_START_APP, 0x00, 0x00000000);
-            mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
+            mcp2515.sendMessage(&canMsg);
 
             // write value of local mcusr into R2
             #if MCUSR_TO_R2
@@ -358,12 +358,12 @@ int main () {
 
             // send flash done verify back
             prepMsg(CMD_FLASH_DONE_VERIFY, 0x00, 0x00000000);
-            mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
+            mcp2515.sendMessage(&canMsg);
 
           } else if (canMsg.data[CAN_DATA_BYTE_CMD] == CMD_START_APP) {
             // just start the main application now
             prepMsg(CMD_START_APP, 0x00, 0x00000000);
-            mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
+            mcp2515.sendMessage(&canMsg);
 
             // write value of local mcusr into R2
             #if MCUSR_TO_R2

--- a/src/bootloader.cpp
+++ b/src/bootloader.cpp
@@ -114,10 +114,12 @@ int main () {
   // reset the CAN controller, go into infinite loop with LED blinking on errors
   if (mcp2515.reset() != MCP2515::ERROR_OK) {
     while (1) {
-      LED_OFF;
-      delay(50);
-      LED_ON;
-      delay(50);
+      #ifdef LED
+        LED_OFF;
+        delay(50);
+        LED_ON;
+        delay(50);
+      #endif
     }
   }
 
@@ -338,9 +340,6 @@ int main () {
             prepMsg(CMD_START_APP, 0x00, 0x00000000);
             mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
 
-            // delay for 50ms to let the mcp send the message
-            delay(50);
-
             // write value of local mcusr into R2
             #if MCUSR_TO_R2
               __asm__ __volatile__("  mov r2,%[mcusr_val] ;Move Between Registers \n\t"
@@ -365,9 +364,6 @@ int main () {
             // just start the main application now
             prepMsg(CMD_START_APP, 0x00, 0x00000000);
             mcp2515.sendMessage(MCP2515::TXBn::TXB0,&canMsg);
-
-            // delay for 50ms to let the mcp send the message
-            delay(50);
 
             // write value of local mcusr into R2
             #if MCUSR_TO_R2

--- a/src/mcp2515.cpp
+++ b/src/mcp2515.cpp
@@ -650,7 +650,12 @@ MCP2515::ERROR MCP2515::sendMessage(const TXBn txbn, const struct can_frame *fra
 
   modifyRegister(txbuf->CTRL, TXB_TXREQ, TXB_TXREQ);
 
-  uint8_t ctrl = readRegister(txbuf->CTRL);
+  // wait for transmission to complete
+  uint8_t ctrl = 0x00;
+  do {
+    ctrl = readRegister(txbuf->CTRL);
+  } while (ctrl & TXB_TXREQ);
+
   if ((ctrl & (TXB_ABTF | TXB_MLOA | TXB_TXERR)) != 0) {
     return ERROR_FAILTX;
   }

--- a/src/mcp2515.cpp
+++ b/src/mcp2515.cpp
@@ -108,45 +108,7 @@ MCP2515::ERROR MCP2515::reset(void) {
 
   delay(10);
 
-  uint8_t zeros[14];
-  memset(zeros, 0, sizeof(zeros));
-  setRegisters(MCP_TXB0CTRL, zeros, 14);
-  setRegisters(MCP_TXB1CTRL, zeros, 14);
-  setRegisters(MCP_TXB2CTRL, zeros, 14);
-
-  setRegister(MCP_RXB0CTRL, 0);
-  setRegister(MCP_RXB1CTRL, 0);
-
   setRegister(MCP_CANINTE, CANINTF_RX0IF | CANINTF_RX1IF | CANINTF_ERRIF | CANINTF_MERRF);
-
-  // receives all valid messages using either Standard or Extended Identifiers that
-  // meet filter criteria. RXF0 is applied for RXB0, RXF1 is applied for RXB1
-  modifyRegister(MCP_RXB0CTRL,
-                 RXBnCTRL_RXM_MASK | RXB0CTRL_BUKT | RXB0CTRL_FILHIT_MASK,
-                 RXBnCTRL_RXM_STDEXT | RXB0CTRL_BUKT | RXB0CTRL_FILHIT);
-  modifyRegister(MCP_RXB1CTRL,
-                 RXBnCTRL_RXM_MASK | RXB1CTRL_FILHIT_MASK,
-                 RXBnCTRL_RXM_STDEXT | RXB1CTRL_FILHIT);
-
-  // clear filters and masks
-  // do not filter any standard frames for RXF0 used by RXB0
-  // do not filter any extended frames for RXF1 used by RXB1
-  RXF filters[] = {RXF0, RXF1, RXF2, RXF3, RXF4, RXF5};
-  for (int i=0; i<6; i++) {
-    bool ext = (i == 1);
-    ERROR result = setFilter(filters[i], ext, 0);
-    if (result != ERROR_OK) {
-      return result;
-    }
-  }
-
-  MASK masks[] = {MASK0, MASK1};
-  for (int i=0; i<2; i++) {
-    ERROR result = setFilterMask(masks[i], true, 0);
-    if (result != ERROR_OK) {
-      return result;
-    }
-  }
 
   return ERROR_OK;
 }

--- a/src/mcp2515.h
+++ b/src/mcp2515.h
@@ -484,7 +484,6 @@ class MCP2515
         ERROR setBitrate(const CAN_SPEED canSpeed, const CAN_CLOCK canClock);
         ERROR setFilterMask(const MASK num, const bool ext, const uint32_t ulData);
         ERROR setFilter(const RXF num, const bool ext, const uint32_t ulData);
-        ERROR sendMessage(const TXBn txbn, const struct can_frame *frame);
         ERROR sendMessage(const struct can_frame *frame);
         ERROR readMessage(struct can_frame *frame);
         bool checkReceive(void);

--- a/src/mcp2515.h
+++ b/src/mcp2515.h
@@ -486,7 +486,6 @@ class MCP2515
         ERROR setFilter(const RXF num, const bool ext, const uint32_t ulData);
         ERROR sendMessage(const TXBn txbn, const struct can_frame *frame);
         ERROR sendMessage(const struct can_frame *frame);
-        ERROR readMessage(const RXBn rxbn, struct can_frame *frame);
         ERROR readMessage(struct can_frame *frame);
         bool checkReceive(void);
         bool checkError(void);


### PR DESCRIPTION
@crycode-de I was able to reduce the size of the bootloader with these commits. It saved ~600bytes of flash memory, which isn't too much, but I thought it was worth checking out. From my usage/testing, I haven't noticed any issue with these changes (so far).

### Usage Before (main branch built for ATmega328P)
```
RAM:   [=         ]   9.4% (used 192 bytes from 2048 bytes)
Flash: [=         ]  11.5% (used 3698 bytes from 32256 bytes)
```
### Usage After (size-optimization branch built for ATmega328P)
```
RAM:   [=         ]   8.2% (used 168 bytes from 2048 bytes)
Flash: [=         ]   9.6% (used 3084 bytes from 32256 bytes)
```

In the title of each commit message, I included how many bytes each change saved. Let me know what you think. Maybe you'll only want to take a few of the commits.