### PR TITLE
Added support for ATmega328PB

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For controlling the MCP2515 a modified version of the [Arduino MCP2515 CAN inter
 
 * [ATmega32](http://ww1.microchip.com/downloads/en/devicedoc/doc2503.pdf)
 * [ATmega328P](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7810-Automotive-Microcontrollers-ATmega328P_Datasheet.pdf)
+* [ATmega328PB](https://ww1.microchip.com/downloads/en/DeviceDoc/40001906A.pdf)
 * [ATmega32U4](https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-7766-8-bit-AVR-ATmega16U4-32U4_Datasheet.pdf)
 * [ATmega64](http://ww1.microchip.com/downloads/en/DeviceDoc/atmel-2490-8-bit-avr-microcontroller-atmega64-l_datasheet.pdf)
 * [ATmega644P](https://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-42744-ATmega644P_Datasheet.pdf)
@@ -360,6 +361,10 @@ Additionally a *start app* command may be send at any time by the flash applicat
 ![Communication example](./doc/flash-sequence.svg)
 
 ## Changelog
+
+## 1.4.1 (2024-08-12)
+
+* Added support for _ATmega328PB_ 
 
 ## 1.4.0 (2023-06-12)
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -69,6 +69,15 @@ build_flags =
 ;board_fuses.hfuse = 0xD8
 ;board_fuses.efuse = 0xFC
 
+[env:ATmega328PB]
+board = ATmega328PB
+build_flags =
+  ${env.build_flags}
+  -Wl,--section-start=.text=0x7000 ; 2048 words bootloader, 0x3800 * 2
+
+;board_fuses.lfuse = 0xFF
+;board_fuses.hfuse = 0xD8
+;board_fuses.efuse = 0xFC
 
 [env:ATmega64]
 board = ATmega64

--- a/src/controllers.h
+++ b/src/controllers.h
@@ -48,7 +48,7 @@
   #define SPI_MISO 3
   #define SPI_SCK 1
 
-#elif defined(__AVR_ATmega328P__)
+#elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega328PB__)
   #define IV_REG MCUCR
 
   #define SPI_DDR  DDRB


### PR DESCRIPTION
Added support for ATmega328PB.

As you stated in #14:

> ATmega328PB is not a drop-in replacement for ATmega328 variants, but a
new device. However, the functions are backward compatible with the
existing ATmega328 functions. Existing code for these devices will work in
the new devices without changing existing configuration or enabling new
functions. The code that is available for your existing ATmega328 variants
will continue to work on the new ATmega328PB device.

I tested it on my Arduino Pro Mini 5V 16MHz clone board and it works perfectly.